### PR TITLE
upgrade to log4j-2.0-rc2-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,21 +61,21 @@ publishing {
 }
 
 dependencies {
-    
-	// JACKSON for JSONification 
+
+	// JACKSON for JSONification
 	def jacksonVersion = '2.3.0'
 	compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
 	compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
 	compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-	
-	def log4j2Version = '2.0-rc1';
+
+	def log4j2Version = '2.0-rc2-SNAPSHOT';
 	compile "org.apache.logging.log4j:log4j-api:$log4j2Version"
 	compile "org.apache.logging.log4j:log4j-core:$log4j2Version"
-			
+
 	// APACHE COMMONS
 	compile 'org.apache.commons:commons-lang3:3.2.1'
 
-	// Testing stuff, hamcrest comes first please 
+	// Testing stuff, hamcrest comes first please
 	testCompile 'org.hamcrest:hamcrest-all:1.3'
 	testCompile 'org.testng:testng:6.8.5'
 	testCompile 'commons-collections:commons-collections:3.2.1'
@@ -103,7 +103,7 @@ test {
 	useTestNG() {
 		excludeGroups 'integration'
 	}
-	
+
 }
 
 task integrationTest(type: Test, dependsOn: ['test']) {
@@ -115,7 +115,7 @@ task integrationTest(type: Test, dependsOn: ['test']) {
 	// copy resource over???
 
 	// set a system property for the test JVM(s)
-	
+
 	doFirst {
 		logger.info 'Logstash required for integration tests'
 //  start logstash or check for logstash and fail


### PR DESCRIPTION
Changes required to build against the next version of log4j2 "2.0-rc2".

Again it's worth adding "?w=1" to the url to avoid the whitespace changes.
 (maybe it's worth making it a project standard not to add trailing whitespace?)

I did this work in correspondence with https://issues.apache.org/jira/browse/LOG4J2-673
