### PR TITLE
Jackson is only used by tests; changed to testCompile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ gradle.properties
 /bin
 gradle.properties.off
 /target/
+.idea/
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -62,23 +62,20 @@ publishing {
 
 dependencies {
 
-	// JACKSON for JSONification
-	def jacksonVersion = '2.3.0'
-	compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-	compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
-	compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-
 	def log4j2Version = '2.0-rc2';
 	compile "org.apache.logging.log4j:log4j-api:$log4j2Version"
 	compile "org.apache.logging.log4j:log4j-core:$log4j2Version"
-
-	// APACHE COMMONS
-	compile 'org.apache.commons:commons-lang3:3.2.1'
 
 	// Testing stuff, hamcrest comes first please
 	testCompile 'org.hamcrest:hamcrest-all:1.3'
 	testCompile 'org.testng:testng:6.8.5'
 	testCompile 'commons-collections:commons-collections:3.2.1'
+
+	// JACKSON for JSONification
+	def jacksonVersion = '2.3.0'
+	testCompile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+	testCompile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+	testCompile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 }
 
 


### PR DESCRIPTION
- Jackson is only used by tests; changed to testCompile.
- Removed unused dependency commons-lang3
- Bump log4j2Version to 2.0-rc2
