### PR TITLE
Properties field should be a JSON hash, and not array of hashes.

### DIFF
--- a/src/main/java/net/logstash/logging/log4j2/core/layout/LogStashJSONLayout.java
+++ b/src/main/java/net/logstash/logging/log4j2/core/layout/LogStashJSONLayout.java
@@ -444,23 +444,17 @@ public class LogStashJSONLayout extends AbstractStringLayout {
             buf.append(COMMA);
             buf.append(this.eol);
             buf.append(this.indent2);
-            buf.append("\"Properties\":[");
+            buf.append("\"Properties\":{");
             buf.append(this.eol);
             final Set<Entry<String, String>> entrySet = event.getContextMap().entrySet();
             int i = 1;
             for (final Map.Entry<String, String> entry : entrySet) {
                 buf.append(this.indent3);
-                buf.append('{');
-                buf.append(this.eol);
-                buf.append(this.indent4);
                 buf.append("\"");
                 buf.append(Transform.escapeJsonControlCharacters(entry.getKey()));
                 buf.append("\":\"");
                 buf.append(Transform.escapeJsonControlCharacters(String.valueOf(entry.getValue())));
                 buf.append("\"");
-                buf.append(this.eol);
-                buf.append(this.indent3);
-                buf.append("}");
                 if (i < entrySet.size()) {
                     buf.append(COMMA);
                 }
@@ -468,7 +462,7 @@ public class LogStashJSONLayout extends AbstractStringLayout {
                 i++;
             }
             buf.append(this.indent2);
-            buf.append("]");
+            buf.append("}");
         }
 
         //Log (the sublayout)


### PR DESCRIPTION
This allows ElasticSearch to treat Properties as an Object, instead of Array when indexing.
Making easier to search/analyze, and optimize our schema according to pre-defined Property values.

As it is now for the Properties element:
"Properties":[ {"some_key":"some_value"},{"key_2":"value_2"} ]
But should be:
"Properties":{"some_key":"some_value","key_2":"value_2"}

ES Objects maps much better to this use case (logging) where Properties tend to be unique...
http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/mapping-object-type.html
http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/mapping-array-type.html
