### PR TITLE
Updated the logstash codec example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Example logstash configuration (later we refer to this as file tcp-logstash.conf
 
     input {
       tcp {
-        codec => json_line { charset => "UTF-8" }
+        codec => json_lines { charset => "UTF-8" }
         # 4560 is default log4j socket appender port
         port => 4560
       }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-log4j2-logstash-jsonevent-layout
-================================
+[![Circle CI](https://circleci.com/gh/jdavis7257/log4j2-logstash-jsonevent-layout.svg?style=svg)](https://circleci.com/gh/jdavis7257/log4j2-logstash-jsonevent-layout)
+log4j2-logstash-jsonevent-layout 
+================================ 
+
 
 Log4J2 Layout as a Logstash "json_event"
 


### PR DESCRIPTION
A json_line codec doesn't exist. json_lines is the correct codec to use in the logstash config.