### PR TITLE
Updated to support log4j 2.6.2 and jackson 2.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Example Log4j2 log4j2.xml:
        <appenders>
           <!-- logstash tcp stocket example, replace host value -->
           <Socket name="LogStashSocket" host="REPLACE_HOST_NAME" port="4560" protocol="tcp">
-    	      <LogStashJSONLayout>
+    	      <LogStashJSONLayout compact="true" eventEol="true">
         			
     			<!-- Example of what you might do to add fields, warning values should be known to be json escaped strings -->
     		    <KeyValuePair key="application_name" value="${sys:application.name}"/>
@@ -69,7 +69,7 @@ Example logstash configuration (later we refer to this as file tcp-logstash.conf
 
     input {
       tcp {
-        codec => json_line { charset => "UTF-8" }
+        codec => json_lines { charset => "UTF-8" }
         # 4560 is default log4j socket appender port
         port => 4560
       }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ description = 'Log4J2 Layout for outputting LogStash json_event format'
 
 apply plugin: 'java'
 
-version='4.2.0'
+version='4.2.1'
 group = 'net.logstash.log4j2'
 
 buildscript {
@@ -68,7 +68,7 @@ publishing {
 
 dependencies {
 
-    def log4j2Version = '2.6.2';
+    def log4j2Version = '2.8.2';
     compile "org.apache.logging.log4j:log4j-api:$log4j2Version"
     compile "org.apache.logging.log4j:log4j-core:$log4j2Version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ description = 'Log4J2 Layout for outputting LogStash json_event format'
 
 apply plugin: 'java'
 
-version='4.1.0'
+version='4.2.0'
 group = 'net.logstash.log4j2'
 
 buildscript {
@@ -17,6 +17,12 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
+    }
+}
+
+allprojects {
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << "-Xlint:deprecation"
     }
 }
 
@@ -62,7 +68,7 @@ publishing {
 
 dependencies {
 
-    def log4j2Version = '2.5';
+    def log4j2Version = '2.6.2';
     compile "org.apache.logging.log4j:log4j-api:$log4j2Version"
     compile "org.apache.logging.log4j:log4j-core:$log4j2Version"
 
@@ -74,7 +80,7 @@ dependencies {
     testCompile 'commons-collections:commons-collections:3.+'
 
     // JACKSON for JSONification
-    def jacksonVersion = '2.+'
+    def jacksonVersion = '2.8.3'
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"

--- a/src/main/java/org/apache/logging/log4j/core/LogStashLogEvent.java
+++ b/src/main/java/org/apache/logging/log4j/core/LogStashLogEvent.java
@@ -12,6 +12,9 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.impl.ThrowableProxy;
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.SortedArrayStringMap;
+
 
 /**
  * To serialize with mixin AND add two properties (@version and @timestamp) we
@@ -28,12 +31,12 @@ public class LogStashLogEvent implements LogEvent{
 
     private LogEvent wrappedLogEvent;
 
-    private Map<String,String> contextMap = new HashMap<String,String>();
+    private SortedArrayStringMap contextMap = new SortedArrayStringMap();
 
 
     public LogStashLogEvent(LogEvent wrappedLogEvent) {
         this.wrappedLogEvent = wrappedLogEvent;
-        contextMap.putAll(wrappedLogEvent.getContextMap());
+        contextMap.putAll(wrappedLogEvent.getContextData());
     }
 
     public String getVersion() {
@@ -46,7 +49,7 @@ public class LogStashLogEvent implements LogEvent{
 
     @Override
     public Map<String, String> getContextMap() {
-        return contextMap;
+        return new HashMap<String,String>();
     }
 
     @Override
@@ -139,6 +142,17 @@ public class LogStashLogEvent implements LogEvent{
     public long getNanoTime() {
         return wrappedLogEvent.getNanoTime();
     }
+
+     @Override
+     public ReadOnlyStringMap getContextData() {
+         return contextMap;
+     }
+
+     @Override
+     public LogEvent toImmutable() {
+        return null;
+     }
+
 
     /**
      * Converter used by JsonSerilize annotation on mixin.

--- a/src/main/java/org/apache/logging/log4j/core/LogStashLogEvent.java
+++ b/src/main/java/org/apache/logging/log4j/core/LogStashLogEvent.java
@@ -3,6 +3,7 @@ package org.apache.logging.log4j.core;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.util.StdConverter;
@@ -27,8 +28,12 @@ public class LogStashLogEvent implements LogEvent{
 
     private LogEvent wrappedLogEvent;
 
+    private Map<String,String> contextMap = new HashMap<String,String>();
+
+
     public LogStashLogEvent(LogEvent wrappedLogEvent) {
         this.wrappedLogEvent = wrappedLogEvent;
+        contextMap.putAll(wrappedLogEvent.getContextMap());
     }
 
     public String getVersion() {
@@ -41,7 +46,7 @@ public class LogStashLogEvent implements LogEvent{
 
     @Override
     public Map<String, String> getContextMap() {
-        return wrappedLogEvent.getContextMap();
+        return contextMap;
     }
 
     @Override

--- a/src/main/java/org/apache/logging/log4j/core/LogStashLogEvent.java
+++ b/src/main/java/org/apache/logging/log4j/core/LogStashLogEvent.java
@@ -90,6 +90,16 @@ public class LogStashLogEvent implements LogEvent{
     }
 
     @Override
+    public int getThreadPriority() {
+        return wrappedLogEvent.getThreadPriority();
+    }
+
+    @Override
+    public long getThreadId() {
+        return wrappedLogEvent.getThreadId();
+    }
+
+    @Override
     public Throwable getThrown() {
         return wrappedLogEvent.getThrown();
     }

--- a/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLog4jJsonModule.java
+++ b/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLog4jJsonModule.java
@@ -11,8 +11,8 @@ public class LogStashLog4jJsonModule extends Log4jJsonModule {
 
     private static final long serialVersionUID = 1L;
 
-    LogStashLog4jJsonModule() {
-        super();
+    LogStashLog4jJsonModule(final boolean encodeThreadContextAsList) {
+        super(encodeThreadContextAsList);
     }
 
 

--- a/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLog4jJsonModule.java
+++ b/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLog4jJsonModule.java
@@ -11,8 +11,8 @@ public class LogStashLog4jJsonModule extends Log4jJsonModule {
 
     private static final long serialVersionUID = 1L;
 
-    LogStashLog4jJsonModule(final boolean encodeThreadContextAsList) {
-        super(encodeThreadContextAsList);
+    LogStashLog4jJsonModule(final boolean encodeThreadContextAsList, final boolean includeStackTrace) {
+        super(encodeThreadContextAsList, includeStackTrace);
     }
 
 

--- a/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLog4jJsonObjectMapper.java
+++ b/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLog4jJsonObjectMapper.java
@@ -12,8 +12,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class LogStashLog4jJsonObjectMapper extends ObjectMapper {
 
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a new instance using the {@link LogStashLog4jJsonModule}.
+     */
     public LogStashLog4jJsonObjectMapper() {
-        this.registerModule(new LogStashLog4jJsonModule());
+        this(false);
+    }
+
+    /**
+     * Create a new instance using the {@link LogStashLog4jJsonModule}.
+     *
+     * @param encodeThreadContextAsList
+     *            when true, make ThreadContext map to be a list of map entries where each entry has a "key" attribute with the key value and a "value" attribute with the value value (old behavior), instead of "natural" JSON/YAML map
+     */
+    public LogStashLog4jJsonObjectMapper(final boolean encodeThreadContextAsList) {
+        this.registerModule(new LogStashLog4jJsonModule(encodeThreadContextAsList));
         this.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
     }
 

--- a/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLog4jJsonObjectMapper.java
+++ b/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLog4jJsonObjectMapper.java
@@ -18,7 +18,7 @@ public class LogStashLog4jJsonObjectMapper extends ObjectMapper {
      * Create a new instance using the {@link LogStashLog4jJsonModule}.
      */
     public LogStashLog4jJsonObjectMapper() {
-        this(false);
+        this(false, true);
     }
 
     /**
@@ -26,9 +26,11 @@ public class LogStashLog4jJsonObjectMapper extends ObjectMapper {
      *
      * @param encodeThreadContextAsList
      *            when true, make ThreadContext map to be a list of map entries where each entry has a "key" attribute with the key value and a "value" attribute with the value value (old behavior), instead of "natural" JSON/YAML map
+     * @param includeStackTrace
+     *            If "true", includes the stacktrace of any Throwable in the generated JSON, defaults to "true".
      */
-    public LogStashLog4jJsonObjectMapper(final boolean encodeThreadContextAsList) {
-        this.registerModule(new LogStashLog4jJsonModule(encodeThreadContextAsList));
+    public LogStashLog4jJsonObjectMapper(final boolean encodeThreadContextAsList, final boolean includeStackTrace) {
+        this.registerModule(new LogStashLog4jJsonModule(encodeThreadContextAsList,includeStackTrace));
         this.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
     }
 

--- a/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLogEventMixIn.java
+++ b/src/main/java/org/apache/logging/log4j/core/jackson/LogStashLogEventMixIn.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonFilter("org.apache.logging.log4j.core.impl.Log4jLogEvent")
 @JsonPropertyOrder({"@version", "timestamp", "timeMillis", "threadName", "level", "loggerName", "marker", "message", "thrown", XmlConstants.ELT_CONTEXT_MAP,
         JsonConstants.ELT_CONTEXT_STACK, "loggerFQCN", "Source", "endOfBatch" })
-abstract class LogStashLogEventMixIn extends LogEventMixIn {
+abstract class LogStashLogEventMixIn extends LogEventJsonMixIn {
 
     @JsonProperty("@timestamp")
     public abstract String getTimestamp();

--- a/src/main/java/org/apache/logging/log4j/core/layout/LogStashJSONLayout.java
+++ b/src/main/java/org/apache/logging/log4j/core/layout/LogStashJSONLayout.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
+import org.apache.logging.log4j.core.LogStashLogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
@@ -209,9 +210,17 @@ public class LogStashJSONLayout extends AbstractJacksonLayout {
      */
     @Override
     public String toSerializable(final LogEvent event) {
-        event.getContextMap().putAll(additionalLogAttributes);
+        //convert event to a LogStashLogEvent, if needed, so that we know we can write to contextMap
+        LogStashLogEvent logStashLogEvent;
+        if (event instanceof LogStashLogEvent) {
+            logStashLogEvent = (LogStashLogEvent) event;
+        } else {
+            logStashLogEvent = new LogStashLogEvent(event);
+        }
+        logStashLogEvent.getContextMap().putAll(additionalLogAttributes);
+
         try {
-            return this.objectWriter.writeValueAsString(event) + eol;
+            return this.objectWriter.writeValueAsString(logStashLogEvent) + eol;
         } catch (final JsonProcessingException e) {
             // Should this be an ISE or IAE?
             LOGGER.error(e);

--- a/src/main/java/org/apache/logging/log4j/core/layout/LogStashJSONLayout.java
+++ b/src/main/java/org/apache/logging/log4j/core/layout/LogStashJSONLayout.java
@@ -18,19 +18,21 @@ package org.apache.logging.log4j.core.layout;
 
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.util.Strings;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Copy Pasta version of JsonLayout that uses a different JSON writer which adds
@@ -41,14 +43,23 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @Plugin(name = "LogStashJSONLayout", category = "Core", elementType = "layout", printObject = true)
 public class LogStashJSONLayout extends AbstractJacksonLayout {
 
+    private static final String DEFAULT_FOOTER = "]";
+
+    private static final String DEFAULT_HEADER = "[";
+
     static final String CONTENT_TYPE = "application/json";
 
     private static final Map<String, String> additionalLogAttributes = new HashMap<String, String>();
 
-    protected LogStashJSONLayout(final boolean locationInfo, final boolean properties, final boolean complete, final boolean compact,
-                                 boolean eventEol, final Charset charset, final Map<String, String> additionalLogAttributes) {
+    protected LogStashJSONLayout(final Configuration config, final boolean locationInfo, final boolean properties,
+            final boolean encodeThreadContextAsList,
+            final boolean complete, final boolean compact, final boolean eventEol, final String headerPattern,
+            final String footerPattern, final Charset charset, final Map<String, String> additionalLogAttributes) {
+        super(config, new LogStashJacksonFactory.JSON(encodeThreadContextAsList).newWriter(locationInfo, properties, compact),
+                charset, compact, complete, eventEol,
+                PatternLayout.createSerializer(config, null, headerPattern, DEFAULT_HEADER, null, false, false),
+                PatternLayout.createSerializer(config, null, footerPattern, DEFAULT_FOOTER, null, false, false));
 
-        super(new LogStashJacksonFactory.JSON().newWriter(locationInfo, properties, compact), charset, compact, complete, eventEol);
         this.additionalLogAttributes.putAll(additionalLogAttributes);
     }
 
@@ -63,7 +74,10 @@ public class LogStashJSONLayout extends AbstractJacksonLayout {
             return null;
         }
         final StringBuilder buf = new StringBuilder();
-        buf.append('[');
+        final String str = serializeToString(getHeaderSerializer());
+        if (str != null) {
+            buf.append(str);
+        }
         buf.append(this.eol);
         return getBytes(buf.toString());
     }
@@ -78,12 +92,19 @@ public class LogStashJSONLayout extends AbstractJacksonLayout {
         if (!this.complete) {
             return null;
         }
-        return getBytes(this.eol + ']' + this.eol);
+        final StringBuilder buf = new StringBuilder();
+        buf.append(this.eol);
+        final String str = serializeToString(getFooterSerializer());
+        if (str != null) {
+            buf.append(str);
+        }
+        buf.append(this.eol);
+        return getBytes(buf.toString());
     }
 
     @Override
     public Map<String, String> getContentFormat() {
-        final Map<String, String> result = new HashMap<String, String>();
+        final Map<String, String> result = new HashMap<>();
         result.put("version", "2.0");
         return result;
     }
@@ -98,35 +119,51 @@ public class LogStashJSONLayout extends AbstractJacksonLayout {
 
     /**
      * Creates a JSON Layout.
-     *
+     * @param config
+     *           The plugin configuration.
      * @param locationInfo
-     *        If "true", includes the location information in the generated JSON.
+     *            If "true", includes the location information in the generated JSON.
      * @param properties
-     *        If "true", includes the thread context in the generated JSON.
+     *            If "true", includes the thread context map in the generated JSON.
+     * @param propertiesAsList
+     *            If true, the thread context map is included as a list of map entry objects, where each entry has
+     *            a "key" attribute (whose value is the key) and a "value" attribute (whose value is the value).
+     *            Defaults to false, in which case the thread context map is included as a simple map of key-value
+     *            pairs.
      * @param complete
-     *        If "true", includes the JSON header and footer, defaults to "false".
+     *            If "true", includes the JSON header and footer, and comma between records.
      * @param compact
-     *        If "true", does not use end-of-lines and indentation, defaults to "false".
+     *            If "true", does not use end-of-lines and indentation, defaults to "false".
      * @param eventEol
-     *        If "true", forces an EOL after each log event (even if compact is "true"), defaults to "false". This
-     *        allows one even per line, even in compact mode.
+     *            If "true", forces an EOL after each log event (even if compact is "true"), defaults to "false". This
+     *            allows one even per line, even in compact mode.
+     * @param headerPattern
+     *            The header pattern, defaults to {@code "["} if null.
+     * @param footerPattern
+     *            The header pattern, defaults to {@code "]"} if null.
      * @param charset
-     *        The character set to use, if {@code null}, uses "UTF-8".
+     *            The character set to use, if {@code null}, uses "UTF-8".
+     * @param pairs
+     *            Additional KeyValue Pairs
      * @return A JSON Layout.
      */
     @PluginFactory
     public static AbstractJacksonLayout createLayout(
             // @formatter:off
+            @PluginConfiguration final Configuration config,
             @PluginAttribute(value = "locationInfo", defaultBoolean = false) final boolean locationInfo,
             @PluginAttribute(value = "properties", defaultBoolean = false) final boolean properties,
+            @PluginAttribute(value = "propertiesAsList", defaultBoolean = false) final boolean propertiesAsList,
             @PluginAttribute(value = "complete", defaultBoolean = false) final boolean complete,
             @PluginAttribute(value = "compact", defaultBoolean = false) final boolean compact,
             @PluginAttribute(value = "eventEol", defaultBoolean = false) final boolean eventEol,
+            @PluginAttribute(value = "header", defaultString = DEFAULT_HEADER) final String headerPattern,
+            @PluginAttribute(value = "footer", defaultString = DEFAULT_FOOTER) final String footerPattern,
             @PluginAttribute(value = "charset", defaultString = "UTF-8") final Charset charset,
             @PluginElement("Pairs") final KeyValuePair[] pairs
             // @formatter:on
     ) {
-
+        final boolean encodeThreadContextAsList = properties && propertiesAsList;
 
         //Unpacke the pairs list
         final Map<String, String> additionalLogAttributes = new HashMap<String, String>();
@@ -150,18 +187,18 @@ public class LogStashJSONLayout extends AbstractJacksonLayout {
 
         }
 
-
-        return new LogStashJSONLayout(locationInfo, properties, complete, compact, eventEol, charset, additionalLogAttributes);
-
+        return new LogStashJSONLayout(config, locationInfo, properties, encodeThreadContextAsList, complete, compact, eventEol,
+                headerPattern, footerPattern, charset, additionalLogAttributes);
     }
 
     /**
-     * Creates a JSON Layout using the default settings.
+     * Creates a JSON Layout using the default settings. Useful for testing.
      *
      * @return A JSON Layout.
      */
     public static AbstractJacksonLayout createDefaultLayout() {
-        return new LogStashJSONLayout(false, false, false, false, false, UTF_8, new HashMap<String,String>());
+        return new LogStashJSONLayout(new DefaultConfiguration(), false, false, false, false, false, false,
+                DEFAULT_HEADER, DEFAULT_FOOTER, StandardCharsets.UTF_8, new HashMap<String,String>());
     }
 
     /**
@@ -181,7 +218,4 @@ public class LogStashJSONLayout extends AbstractJacksonLayout {
             return Strings.EMPTY;
         }
     }
-
-
-
 }

--- a/src/main/java/org/apache/logging/log4j/core/layout/LogStashJacksonFactory.java
+++ b/src/main/java/org/apache/logging/log4j/core/layout/LogStashJacksonFactory.java
@@ -15,8 +15,13 @@ import java.util.Set;
  *
  * Created by jeremyfranklin-ross on 7/27/15.
  */
-abstract  class LogStashJacksonFactory extends JacksonFactory {
+abstract class LogStashJacksonFactory extends JacksonFactory {
         static class JSON extends JacksonFactory.JSON {
+
+            public JSON(final boolean encodeThreadContextAsList) {
+                super(encodeThreadContextAsList);
+            }
+
             @Override
             protected ObjectMapper newObjectMapper() {
                 return new LogStashLog4jJsonObjectMapper();

--- a/src/main/java/org/apache/logging/log4j/core/layout/LogStashJacksonFactory.java
+++ b/src/main/java/org/apache/logging/log4j/core/layout/LogStashJacksonFactory.java
@@ -18,8 +18,8 @@ import java.util.Set;
 abstract class LogStashJacksonFactory extends JacksonFactory {
         static class JSON extends JacksonFactory.JSON {
 
-            public JSON(final boolean encodeThreadContextAsList) {
-                super(encodeThreadContextAsList);
+            public JSON(final boolean encodeThreadContextAsList, final boolean includeStacktrace) {
+                super(encodeThreadContextAsList, includeStacktrace);
             }
 
             @Override

--- a/src/test/java/org/apache/logging/log4j/core/layout/LogStashJSONLayoutJacksonIT.java
+++ b/src/test/java/org/apache/logging/log4j/core/layout/LogStashJSONLayoutJacksonIT.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.util.KeyValuePair;
@@ -66,27 +67,26 @@ public class LogStashJSONLayoutJacksonIT {
         Map<String,String>  mdc =     new HashMap<String,String>();
         mdc.put("A","B");//Already some threadcontext
 
-        LogEvent event = new Log4jLogEvent(
-                logger.getName(),
-                null,
-                this.getClass().getCanonicalName(),
-                Level.DEBUG,
-                simpleMessage,
-                null,
-                mdc,
-                null,
-                Thread.currentThread().getName(),
-                null,
-                System.currentTimeMillis()
-                );
-
+       Log4jLogEvent.Builder builder = new Log4jLogEvent.Builder();
+         builder.setLoggerName(logger.getName());
+         builder.setLoggerFqcn(this.getClass().getCanonicalName());
+         builder.setLevel(Level.DEBUG);
+         builder.setMessage(simpleMessage);
+         builder.setContextMap(mdc);
+         builder.setThreadName(Thread.currentThread().getName());
+         builder.setTimeMillis(System.currentTimeMillis());
+       LogEvent event = builder.build();
 
         AbstractJacksonLayout layout = LogStashJSONLayout.createLayout(
-                true, //location
+                new DefaultConfiguration(),
+                true, //locationInfo
                 true, //properties
+                false, //propertiesAsList
                 true, //complete
                 false, //compact
                 false, //eventEol
+                "[", //header
+                "]", //footer
                 Charset.defaultCharset(),
                 new KeyValuePair[]{new KeyValuePair("Foo", "Bar")}
         );

--- a/src/test/java/org/apache/logging/log4j/core/layout/LogStashJSONLayoutJacksonIT.java
+++ b/src/test/java/org/apache/logging/log4j/core/layout/LogStashJSONLayoutJacksonIT.java
@@ -98,5 +98,90 @@ public class LogStashJSONLayoutJacksonIT {
                 .allowingAnyArrayOrdering());
 
     }
+    String expectedEmptyMDCTestJSON = "{\"@version\":\"1\"," +
+            // "\"@timestamp\":\"2015-07-28T11:31:18.492-07:00\",\"timeMillis\":1438108278492," +
+            "\"thread\":\""+ Thread.currentThread().getName() +"\"," +
+            "\"level\":\"DEBUG\"," +
+            "\"loggerName\":\"org.apache.logging.log4j.core.layout.LogStashJSONLayoutJacksonIT\"," +
+            "\"message\":\"Test Message\"," +
+            "\"endOfBatch\":false," +
+            "\"loggerFqcn\":\"org.apache.logging.log4j.core.layout.LogStashJSONLayoutJacksonIT\"}";
+
+    @Test
+    public void EmptyMDCTest() throws Exception {
+        Message simpleMessage = new SimpleMessage("Test Message");
+
+        Map<String,String>  mdc =     new HashMap<String,String>();
+
+        Log4jLogEvent.Builder builder = new Log4jLogEvent.Builder();
+          builder.setLoggerName(logger.getName());
+          builder.setLoggerFqcn(this.getClass().getCanonicalName());
+          builder.setLevel(Level.DEBUG);
+          builder.setMessage(simpleMessage);
+          builder.setContextMap(mdc);
+          builder.setThreadName(Thread.currentThread().getName());
+          builder.setTimeMillis(System.currentTimeMillis());
+        LogEvent event = builder.build();
+
+         AbstractJacksonLayout layout = LogStashJSONLayout.createLayout(
+                 new DefaultConfiguration(),
+                 true, //locationInfo
+                 true, //properties
+                 false, //propertiesAsList
+                 true, //complete
+                 false, //compact
+                 false, //eventEol
+                 "[", //header
+                 "]", //footer
+                 Charset.defaultCharset(),
+                 new KeyValuePair[]{new KeyValuePair("Foo", "Bar")}
+         );
+
+        String actualJSON = layout.toSerializable(event);
+        System.out.println(actualJSON);
+        assertThat(actualJSON, sameJSONAs(expectedEmptyMDCTestJSON)
+                .allowingExtraUnexpectedFields()
+                .allowingAnyArrayOrdering());
+
+    }
+
+    @Test
+    public void NullMDCTest() throws Exception {
+        Message simpleMessage = new SimpleMessage("Test Message");
+
+        Map<String,String>  mdc = null;
+
+        Log4jLogEvent.Builder builder = new Log4jLogEvent.Builder();
+          builder.setLoggerName(logger.getName());
+          builder.setLoggerFqcn(this.getClass().getCanonicalName());
+          builder.setLevel(Level.DEBUG);
+          builder.setMessage(simpleMessage);
+          builder.setContextMap(mdc);
+          builder.setThreadName(Thread.currentThread().getName());
+          builder.setTimeMillis(System.currentTimeMillis());
+        LogEvent event = builder.build();
+
+         AbstractJacksonLayout layout = LogStashJSONLayout.createLayout(
+                 new DefaultConfiguration(),
+                 true, //locationInfo
+                 true, //properties
+                 false, //propertiesAsList
+                 true, //complete
+                 false, //compact
+                 false, //eventEol
+                 "[", //header
+                 "]", //footer
+                 Charset.defaultCharset(),
+                 new KeyValuePair[]{new KeyValuePair("Foo", "Bar")}
+         );
+
+        String actualJSON = layout.toSerializable(event);
+        System.out.println(actualJSON);
+        assertThat(actualJSON, sameJSONAs(expectedEmptyMDCTestJSON)
+                .allowingExtraUnexpectedFields()
+                .allowingAnyArrayOrdering());
+
+    }
+
 
 }

--- a/src/test/java/org/apache/logging/log4j/core/layout/LogStashJSONLayoutJacksonIT.java
+++ b/src/test/java/org/apache/logging/log4j/core/layout/LogStashJSONLayoutJacksonIT.java
@@ -18,6 +18,8 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.SortedArrayStringMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
@@ -58,21 +60,21 @@ public class LogStashJSONLayoutJacksonIT {
                     "\"message\":\"Test Message\"," +
                     "\"endOfBatch\":false," +
                     "\"loggerFqcn\":\"org.apache.logging.log4j.core.layout.LogStashJSONLayoutJacksonIT\","+
-                    "\"contextMap\":[{\"key\":\"Foo\",\"value\":\"Bar\"},{\"key\":\"A\",\"value\":\"B\"}]}";
+                    "\"contextMap\":{\"A\":\"B\",\"Foo\":\"Bar\"}}";
 
     @Test
     public void BasicSimpleTest() throws Exception {
         Message simpleMessage = new SimpleMessage("Test Message");
 
-        Map<String,String>  mdc =     new HashMap<String,String>();
-        mdc.put("A","B");//Already some threadcontext
+        SortedArrayStringMap mdc =     new SortedArrayStringMap();
+        mdc.putValue("A","B");//Already some threadcontext
 
        Log4jLogEvent.Builder builder = new Log4jLogEvent.Builder();
          builder.setLoggerName(logger.getName());
          builder.setLoggerFqcn(this.getClass().getCanonicalName());
          builder.setLevel(Level.DEBUG);
          builder.setMessage(simpleMessage);
-         builder.setContextMap(mdc);
+         builder.setContextData(mdc);
          builder.setThreadName(Thread.currentThread().getName());
          builder.setTimeMillis(System.currentTimeMillis());
        LogEvent event = builder.build();
@@ -88,6 +90,7 @@ public class LogStashJSONLayoutJacksonIT {
                 "[", //header
                 "]", //footer
                 Charset.defaultCharset(),
+                true, //includeStackTrace
                 new KeyValuePair[]{new KeyValuePair("Foo", "Bar")}
         );
 
@@ -111,14 +114,14 @@ public class LogStashJSONLayoutJacksonIT {
     public void EmptyMDCTest() throws Exception {
         Message simpleMessage = new SimpleMessage("Test Message");
 
-        Map<String,String>  mdc =     new HashMap<String,String>();
+        SortedArrayStringMap  mdc =     new SortedArrayStringMap();
 
         Log4jLogEvent.Builder builder = new Log4jLogEvent.Builder();
           builder.setLoggerName(logger.getName());
           builder.setLoggerFqcn(this.getClass().getCanonicalName());
           builder.setLevel(Level.DEBUG);
           builder.setMessage(simpleMessage);
-          builder.setContextMap(mdc);
+          builder.setContextData(mdc);
           builder.setThreadName(Thread.currentThread().getName());
           builder.setTimeMillis(System.currentTimeMillis());
         LogEvent event = builder.build();
@@ -134,6 +137,7 @@ public class LogStashJSONLayoutJacksonIT {
                  "[", //header
                  "]", //footer
                  Charset.defaultCharset(),
+                 true, //includeStackTrace
                  new KeyValuePair[]{new KeyValuePair("Foo", "Bar")}
          );
 
@@ -149,14 +153,14 @@ public class LogStashJSONLayoutJacksonIT {
     public void NullMDCTest() throws Exception {
         Message simpleMessage = new SimpleMessage("Test Message");
 
-        Map<String,String>  mdc = null;
+        SortedArrayStringMap  mdc = null;
 
         Log4jLogEvent.Builder builder = new Log4jLogEvent.Builder();
           builder.setLoggerName(logger.getName());
           builder.setLoggerFqcn(this.getClass().getCanonicalName());
           builder.setLevel(Level.DEBUG);
           builder.setMessage(simpleMessage);
-          builder.setContextMap(mdc);
+          builder.setContextData(mdc);
           builder.setThreadName(Thread.currentThread().getName());
           builder.setTimeMillis(System.currentTimeMillis());
         LogEvent event = builder.build();
@@ -172,6 +176,7 @@ public class LogStashJSONLayoutJacksonIT {
                  "[", //header
                  "]", //footer
                  Charset.defaultCharset(),
+                 true, //includeStackTrace
                  new KeyValuePair[]{new KeyValuePair("Foo", "Bar")}
          );
 


### PR DESCRIPTION
- updated to support log4j 2.6.2 and jackson 2.8.3, also removed deprecation warnings.
- Included commit from branch issue/27-redux, as I could not get anything working without that.
- Updated README since I could not find a plugin called json_line.  But there is one called json_lines. 
  - json_lines does not work without adding config settings compact="true" and eventEol="true"
